### PR TITLE
fix type error occured

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -319,7 +319,6 @@ FTP.prototype.connect = function(options) {
 
   } else {
 
-    secureOptions.socket = socket;
     this._socket = socket;
     socket.once('connect', onconnect);
     this.setupSocket(socket);


### PR DESCRIPTION
Correct "TypeError: Cannot set property 'socket' of undefined" when no secure ftp connect in node.js v6.9.1 .